### PR TITLE
fixes end prompt to start new game without refresh

### DIFF
--- a/public/dom.js
+++ b/public/dom.js
@@ -38,6 +38,9 @@ function handleError() {
 
 //function to display images on tiles
 function displayImages(images) {
+  while (tiles.firstChild) {
+    tiles.removeChild(firstChild);
+  }
   tiles.forEach(function (tile) {
     var img = document.createElement('img');
     tile.appendChild(img);
@@ -102,5 +105,14 @@ startBtn.addEventListener('click', function (e) {
 });
 
 replayBtn.addEventListener('click', function(e) {
-  window.location.reload();
+  makeRequest('/api/', function(images) {
+    handleResponse(images);
+    dialogBackground.style.display = 'none';
+    endDialog.style.display = 'none';
+  }, handleError);
+  tiles.forEach(function(tile) {
+    tile.dataset.matched = 'null';
+  })
 });
+
+


### PR DESCRIPTION
Relates #20 
Fixes double-prompt issue because it doesn't do a simple refresh AND removes children on tiles before adding new ones.

Also, resets data-matched to null again to restart game and flip tiles over